### PR TITLE
feat: Modernize family tree connections and layout

### DIFF
--- a/src/components/FamilyTree.tsx
+++ b/src/components/FamilyTree.tsx
@@ -36,10 +36,10 @@ const nodeTypes = {
 
 // Define layout configuration constants
 const layoutConfig: LayoutConfig = {
-    generationSpacing: 320,
-    memberSpacing: 280,
+    generationSpacing: 280,
+    memberSpacing: 240,
     nodeWidth: 208,
-    siblingSpacing: 30,
+    siblingSpacing: 50,
     // minParentPadding: 20, // Ensure these match what layoutFamilyTree expects if used
     // minFamilyBlockSpacing: 50, // Or remove if not used in the moved logic
 };

--- a/src/lib/layoutFamilyTree.ts
+++ b/src/lib/layoutFamilyTree.ts
@@ -260,11 +260,10 @@ export function layoutFamilyTree(
                       id: `edge-${parentId}-to-${member.id}`,
                       source: parentId,
                       target: member.id,
-                      type: 'smoothstep', 
+                      type: 'default',
                       animated: true,
-                      markerEnd: { type: MarkerType.ArrowClosed, color: '#059669', width: 22, height: 22 },
-                      style: { stroke: '#059669', strokeWidth: 3, strokeLinecap: 'round', filter: 'drop-shadow(0 2px 4px rgba(0,0,0,0.1))'},
-                      pathOptions: { borderRadius: 30 }, 
+                      markerEnd: { type: MarkerType.ArrowClosed, color: '#60a5fa', width: 18, height: 18 },
+                      style: { stroke: '#60a5fa', strokeWidth: 2, strokeLinecap: 'round', filter: 'drop-shadow(0 2px 4px rgba(0,0,0,0.1))'},
                   });
               }
           });


### PR DESCRIPTION
This commit introduces a redesigned node connection style and adjusts the layout spacing for the family tree to enhance visual appeal and clarity.

Key changes:
- Edge style updated in `src/lib/layoutFamilyTree.ts`:
  - Switched from 'smoothstep' to 'default' (Bezier) edge type for a more fluid appearance.
  - Edge stroke color changed to a softer blue (#60a5fa) to complement node design.
  - Edge stroke width reduced to 2px for a lighter feel.
  - Arrowhead marker size and color updated to match the new edge style.
- Layout configuration in `src/components/FamilyTree.tsx` adjusted:
  - `generationSpacing` reduced to 280 for a more compact vertical view.
  - `memberSpacing` reduced to 240.
  - `siblingSpacing` increased to 50 to provide more room for connections between siblings.

These changes aim to create a more modern and evenly spaced family tree, improving the overall user experience.