### PR TITLE
Redesign family tree node connections for modern look.

### DIFF
--- a/src/components/FamilyTree.tsx
+++ b/src/components/FamilyTree.tsx
@@ -36,10 +36,10 @@ const nodeTypes = {
 
 // Define layout configuration constants
 const layoutConfig: LayoutConfig = {
-    generationSpacing: 280,
-    memberSpacing: 240,
+    generationSpacing: 400,
+    memberSpacing: 280,
     nodeWidth: 208,
-    siblingSpacing: 50,
+    siblingSpacing: 70,
     // minParentPadding: 20, // Ensure these match what layoutFamilyTree expects if used
     // minFamilyBlockSpacing: 50, // Or remove if not used in the moved logic
 };

--- a/src/lib/layoutFamilyTree.ts
+++ b/src/lib/layoutFamilyTree.ts
@@ -260,10 +260,10 @@ export function layoutFamilyTree(
                       id: `edge-${parentId}-to-${member.id}`,
                       source: parentId,
                       target: member.id,
-                      type: 'default',
+                      type: 'smoothstep',
                       animated: true,
-                      markerEnd: { type: MarkerType.ArrowClosed, color: '#60a5fa', width: 18, height: 18 },
-                      style: { stroke: '#60a5fa', strokeWidth: 2, strokeLinecap: 'round', filter: 'drop-shadow(0 2px 4px rgba(0,0,0,0.1))'},
+                      markerEnd: { type: MarkerType.ArrowClosed, color: '#60a5fa', width: 20, height: 20 },
+                      style: { stroke: '#60a5fa', strokeWidth: 2.5, filter: 'drop-shadow(0 2px 4px rgba(0,0,0,0.1))'},
                   });
               }
           });


### PR DESCRIPTION
This commit implements a redesign of the family tree's node connections to enhance visual appeal and clarity.

Key changes:
- Increased spacing between generations (`generationSpacing` to 400), members (`memberSpacing` to 280), and siblings (`siblingSpacing` to 70) to provide a less cluttered layout.
- Implemented curly connectors by changing the React Flow edge type to `smoothstep`.
- Adjusted edge styling (stroke width to 2.5, updated marker size) for a more refined appearance that complements the curly design.

These changes aim to create a more modern, aesthetically pleasing, and easy-to-follow family tree visualization, while also improving the avoidance of overlapping elements through better spacing.