### PR TITLE
Feat: Implement hierarchical centering for explicit pyramid structure.

### DIFF
--- a/src/lib/layoutFamilyTree.ts
+++ b/src/lib/layoutFamilyTree.ts
@@ -140,6 +140,7 @@ export function layoutFamilyTree(
 
   const maxGeneration = Math.max(0, ...displayedMembers.map(m => (m.generation || 1)));
   const nodeXPositionsGlobal = new Map<string, number>();
+  let gen1CenterX = viewportWidth / 2; // Default, will be updated after Gen 1 is laid out
 
   // Group nodes by generation for efficient access
   const nodesByGeneration = new Map<number, Node[]>();
@@ -156,120 +157,131 @@ export function layoutFamilyTree(
     if (nodesInCurrentGen.length === 0) continue;
 
     if (g === 1) {
-      // Sort displayedMembers of generation 1 once for stable layout
+      const gen1NodesOnly = nodesInCurrentGen; // Alias for clarity in this block
+
+      // Initial layout of Gen 1 nodes, starting from currentX = 0
       const gen1MembersSorted = displayedMembers
         .filter(m => (m.generation || 1) === 1)
-        .sort((a, b) => a.id.localeCompare(b.id)); // Or some other stable sort key
+        .sort((a, b) => a.id.localeCompare(b.id));
 
       const processedGen1NodeIds = new Set<string>();
-      let currentX = 0;
+      let currentX = 0; // Start initial layout from X = 0
 
       gen1MembersSorted.forEach(memberData => {
-        const node = nodesInCurrentGen.find(n => n.id === memberData.id);
+        const node = gen1NodesOnly.find(n => n.id === memberData.id);
         if (node && !processedGen1NodeIds.has(node.id)) {
           node.position.x = currentX;
+          // nodeXPositionsGlobal.set(node.id, currentX); // Temporarily set, will be updated after shift
           processedGen1NodeIds.add(node.id);
-          nodeXPositionsGlobal.set(node.id, currentX);
-          currentX += nodeWidth + memberSpacing; // Base spacing for next independent node
+          currentX += nodeWidth + memberSpacing;
 
-          // Handle spouse if present and in this generation
           if (memberData.spouse && memberData.spouse !== memberData.id) {
             const spouseMemberData = displayedMembers.find(m => m.id === memberData.spouse && (m.generation || 1) === 1);
             if (spouseMemberData) {
-              const spouseNode = nodesInCurrentGen.find(n => n.id === spouseMemberData.id);
+              const spouseNode = gen1NodesOnly.find(n => n.id === spouseMemberData.id);
               if (spouseNode && !processedGen1NodeIds.has(spouseNode.id)) {
-                // Position spouse right next to the current node
-                spouseNode.position.x = node.position.x + memberSpacing; // More direct positioning
+                spouseNode.position.x = node.position.x + memberSpacing;
+                // nodeXPositionsGlobal.set(spouseNode.id, spouseNode.position.x); // Temp
                 processedGen1NodeIds.add(spouseNode.id);
-                nodeXPositionsGlobal.set(spouseNode.id, spouseNode.position.x);
-                // Adjust currentX to account for the spouse node if it was separately positioned
-                currentX = spouseNode.position.x + nodeWidth + memberSpacing; 
+                currentX = spouseNode.position.x + nodeWidth + memberSpacing;
               }
             }
           }
         }
       });
-       // Fallback for any gen 1 nodes not caught by sorted iteration (e.g. no spouse links but multiple roots)
-       nodesInCurrentGen.forEach(node => {
-        if(!processedGen1NodeIds.has(node.id)){
-            node.position.x = currentX;
-            processedGen1NodeIds.add(node.id);
-            nodeXPositionsGlobal.set(node.id, currentX);
-            currentX += nodeWidth + memberSpacing;
-        }
-       });
 
+      gen1NodesOnly.forEach(node => {
+        if (!processedGen1NodeIds.has(node.id)) {
+          node.position.x = currentX;
+          // nodeXPositionsGlobal.set(node.id, currentX); // Temp
+          processedGen1NodeIds.add(node.id);
+          currentX += nodeWidth + memberSpacing;
+        }
+      });
+
+      // Now, center this entire Gen 1 block
+      if (gen1NodesOnly.length > 0) {
+        const gen1XPositions = gen1NodesOnly.map(n => n.position.x);
+        const minX_gen1 = Math.min(...gen1XPositions);
+        const maxNodeX_gen1 = gen1NodesOnly.map(n => n.position.x + nodeWidth); // nodeWidth from config
+        const maxX_gen1 = Math.max(...maxNodeX_gen1);
+        const gen1Width = maxX_gen1 - minX_gen1;
+
+        const gen1ShiftX = (viewportWidth / 2) - (minX_gen1 + gen1Width / 2);
+
+        gen1NodesOnly.forEach(node => {
+          node.position.x += gen1ShiftX;
+          nodeXPositionsGlobal.set(node.id, node.position.x); // IMPORTANT: Update global X with final centered position
+        });
+
+        // Calculate actual gen1CenterX after centering
+        const finalGen1XPositions = gen1NodesOnly.map(n => nodeXPositionsGlobal.get(n.id)!);
+        if (finalGen1XPositions.length > 0) {
+            const finalMinX_gen1 = Math.min(...finalGen1XPositions);
+            // Ensure nodeWidth is from config for this calculation specifically
+            const finalMaxNodeX_gen1 = gen1NodesOnly.map(n => nodeXPositionsGlobal.get(n.id)! + config.nodeWidth);
+            const finalMaxX_gen1 = Math.max(...finalMaxNodeX_gen1);
+            gen1CenterX = finalMinX_gen1 + (finalMaxX_gen1 - finalMinX_gen1) / 2;
+        }
+      }
 
     } else { // For g > 1
-      // Group nodes by their parent set for structured layout
       const nodesByParentKeyInCurrentGen = new Map<string, Node[]>();
       nodesInCurrentGen.forEach(node => {
         const member = node.data.member as FamilyMember;
         const parentKey = member.parents && member.parents.length > 0
                           ? member.parents.sort().join('-')
-                          : `no-parents-${member.id}`; // Unique key for nodes without parents or distinct roots
+                          : `no-parents-${member.id}`;
         if (!nodesByParentKeyInCurrentGen.has(parentKey)) {
           nodesByParentKeyInCurrentGen.set(parentKey, []);
         }
         nodesByParentKeyInCurrentGen.get(parentKey)!.push(node);
       });
 
-      let currentXForGeneration = 0;
-      // Sort parent keys for deterministic layout order
       const sortedParentKeys = Array.from(nodesByParentKeyInCurrentGen.keys()).sort();
+      const parentGroupDetails: { parentKey: string; siblingGroup: Node[]; groupWidth: number; avgParentX: number }[] = [];
+      let totalWidthOfCurrentGeneration = 0;
 
-      sortedParentKeys.forEach(parentKey => {
+      for (const parentKey of sortedParentKeys) {
         const siblingGroup = nodesByParentKeyInCurrentGen.get(parentKey)!;
+        const groupWidth = (siblingGroup.length * nodeWidth) + ((siblingGroup.length - 1) * siblingSpacing);
+        totalWidthOfCurrentGeneration += groupWidth;
 
-        // Calculate the average X position of the parents of this siblingGroup
-        let avgParentX = 0;
+        let avgParentX = gen1CenterX; // Default to Gen1 center
         if (siblingGroup.length > 0 && siblingGroup[0].data.member.parents && siblingGroup[0].data.member.parents.length > 0) {
           const parentXCoords = siblingGroup[0].data.member.parents
             .map(parentId => nodeXPositionsGlobal.get(parentId))
             .filter(x => x !== undefined) as number[];
           if (parentXCoords.length > 0) {
             avgParentX = parentXCoords.reduce((sum, xVal) => sum + xVal, 0) / parentXCoords.length;
-          } else {
-            // Fallback if parents are not in nodeXPositionsGlobal (e.g., not displayed)
-            // This group will effectively start at currentXForGeneration
-            avgParentX = currentXForGeneration;
           }
-        } else {
-           // No parents (e.g. a new root appearing in a later generation, though unusual for family trees)
-           avgParentX = currentXForGeneration;
         }
-        
-        const groupWidth = (siblingGroup.length * nodeWidth) + ((siblingGroup.length - 1) * siblingSpacing);
+        parentGroupDetails.push({ parentKey, siblingGroup, groupWidth, avgParentX });
+      }
+      if (parentGroupDetails.length > 0) {
+        totalWidthOfCurrentGeneration += (parentGroupDetails.length - 1) * memberSpacing;
+      }
 
-        // Determine the starting X for this group. It's centered under avgParentX,
-        // but must not be less than currentXForGeneration to avoid overlap.
-        let groupStartX = avgParentX - (groupWidth / 2) + (nodeWidth / 2); // target start for first node's center
-        groupStartX = Math.max(groupStartX, currentXForGeneration);
+      let collectiveParentCenterX = gen1CenterX;
+      if (parentGroupDetails.length > 0) {
+        const weightedSum = parentGroupDetails.reduce((sum, detail) => sum + detail.avgParentX * detail.siblingGroup.length, 0);
+        const totalNodesInGen = parentGroupDetails.reduce((sum, detail) => sum + detail.siblingGroup.length, 0);
+        if (totalNodesInGen > 0) {
+          collectiveParentCenterX = weightedSum / totalNodesInGen;
+        }
+      }
 
-        // Position siblings within their group
-        let currentXInGroup = groupStartX;
+      const startXForCurrentGeneration = collectiveParentCenterX - (totalWidthOfCurrentGeneration / 2);
+      let currentXInGenerationBlock = startXForCurrentGeneration;
+
+      parentGroupDetails.forEach(({ siblingGroup, groupWidth }) => {
+        let currentSiblingX = currentXInGenerationBlock;
         siblingGroup.forEach(node => {
-          // node.position.x = currentXInGroup; // This would be for left edge
-          node.position.x = currentXInGroup; // Centering each node
+          node.position.x = currentSiblingX + nodeWidth / 2; // Center of the node
           nodeXPositionsGlobal.set(node.id, node.position.x);
-          currentXInGroup += nodeWidth + siblingSpacing;
+          currentSiblingX += nodeWidth + siblingSpacing;
         });
-
-        // Update currentXForGeneration for the next group
-        // The width of the current group is (currentXInGroup - groupStartX - siblingSpacing)
-        // The rightmost point of the last node is groupStartX + (siblingGroup.length-1)*(nodeWidth+siblingSpacing)
-        // No, it's simpler: the last node's X is node.position.x. Its width is nodeWidth.
-        // So, the space taken is from groupStartX (center of first node) to last node's center + nodeWidth/2
-        // Correct: currentXForGeneration should be the X for the *start* of the next group.
-        // currentXInGroup is already (nodeWidth + siblingSpacing) *beyond* the last node's start.
-        // So currentXForGeneration = currentXInGroup - siblingSpacing + memberSpacing
-        if (siblingGroup.length > 0) {
-             const lastNode = siblingGroup[siblingGroup.length-1];
-             currentXForGeneration = lastNode.position.x + (nodeWidth / 2) + memberSpacing;
-        } else {
-             currentXForGeneration += memberSpacing; // Should not happen if key exists
-        }
-
+        currentXInGenerationBlock += groupWidth + memberSpacing;
       });
     }
     // Global X positions are updated within the loops now.
@@ -296,31 +308,13 @@ export function layoutFamilyTree(
       }
   });
 
-  let centeredNodes = currentLayoutNodes; 
-  if (currentLayoutNodes.length > 0) {
-      // nodeWidth is already available from the destructuring of 'config' at the function start
-      const allXPositions = currentLayoutNodes.map(n => n.position.x);
-      const minX = Math.min(...allXPositions);
-      
-      // Calculate maxX considering the width of the nodes
-      const maxNodeX = currentLayoutNodes.map(n => n.position.x + nodeWidth); // nodeWidth from config
-      const maxX = Math.max(...maxNodeX);
+  // The final global centering logic has been removed.
+  // currentLayoutNodes now contain the positions determined by hierarchical centering.
 
-      const treeActualWidth = maxX - minX;
-
-      // Calculate the shift needed to center the entire tree structure
-      const finalGlobalShiftX = (viewportWidth / 2) - (minX + treeActualWidth / 2);
-
-      centeredNodes = currentLayoutNodes.map(node => ({
-          ...node,
-          position: {
-              ...node.position,
-              x: node.position.x + finalGlobalShiftX,
-          },
-      }));
-  }
-
-  const finalNodesForReactFlow = centeredNodes.map(node => {
+  // The existing finalNodesForReactFlow mapping seems to be a simple clone,
+  // which is fine. If centeredNodes is not reassigned by a removed block,
+  // it will be equal to currentLayoutNodes.
+  const finalNodesForReactFlow = currentLayoutNodes.map(node => {
       return { 
           ...node,
       };


### PR DESCRIPTION
This commit refines the family tree layout to create a more explicit pyramid structure, where Generation 1 is definitively centered in the viewport, and subsequent generations are centered relative to their parent generation's established central axis.

Key changes in `src/lib/layoutFamilyTree.ts`:
1.  Generation 1 nodes are laid out and then their entire block is shifted to be precisely centered within the viewport. The absolute center of Generation 1 (`gen1CenterX`) is stored.
2.  For subsequent generations (g > 1):
    - The layout logic calculates the total width required for all family groups in that generation.
    - It determines a `collectiveParentCenterX` based on the average center of connections from the (already centered) parent generation.
    - The entire block of nodes for the current generation is then positioned so it's centered under this `collectiveParentCenterX`.
    - Family groups within the generation are laid out sequentially within this centered block.
3.  The final global centering step (which centered the entire tree's bounding box) has been removed to ensure the hierarchical centering, starting from Generation 1, dictates the final positions.

This approach should result in a tree that visually starts from a centered Generation 1 and flows downwards with each generation's mass also centered, achieving the requested pyramid appearance.