### PR TITLE
refactor: Adjust member detail display locations per feedback

### DIFF
--- a/src/components/FamilyMemberNode.tsx
+++ b/src/components/FamilyMemberNode.tsx
@@ -1,9 +1,8 @@
 
-import React, { useCallback, useMemo, useEffect, useState } from 'react';
+import React, { useCallback, useMemo } from 'react';
 import { Handle, Position } from '@xyflow/react';
-import { User, Users, Heart, Calendar, Briefcase, Edit, Trash2, PlusCircle, MinusCircle, Phone } from 'lucide-react';
+import { User, Calendar, Briefcase, Edit, Trash2, PlusCircle, MinusCircle, Phone } from 'lucide-react';
 import { FamilyMember } from '../types/family';
-import { supabase } from '../lib/supabaseClient';
 
 interface FamilyMemberNodeProps {
   data: {
@@ -30,60 +29,6 @@ const FamilyMemberNodeInternal: React.FC<FamilyMemberNodeProps> = ({ data }) => 
     onToggleCollapse,
     hasChildren
   } = data;
-
-  const [parentNames, setParentNames] = useState<string | null>(null);
-  const [spousePartnerName, setSpousePartnerName] = useState<string | null>(null);
-
-  const fetchMemberName = async (id: string): Promise<string | null> => {
-    const { data, error } = await supabase
-      .from('family_members')
-      .select('name')
-      .eq('id', id)
-      .single();
-    if (error) {
-      console.error('Error fetching member name:', error);
-      return null;
-    }
-    return data?.name || null;
-  };
-
-  useEffect(() => {
-    if (member.parents && member.parents.length > 0) {
-      const fetchParentNames = async () => {
-        const names = await Promise.all(member.parents.map(fetchMemberName));
-        const validNames = names.filter(name => name !== null) as string[];
-        if (validNames.length > 0) {
-          setParentNames(validNames.join(' & '));
-        } else {
-          setParentNames(null);
-        }
-      };
-      fetchParentNames();
-    } else {
-      setParentNames(null);
-    }
-  }, [member.parents]);
-
-  useEffect(() => {
-    const fetchSpouseOrPartnerNames = async () => {
-      let names: string[] = [];
-      if (member.spouse) {
-        const spouseName = await fetchMemberName(member.spouse);
-        if (spouseName) names.push(spouseName);
-      } else if (member.partners && member.partners.length > 0) {
-        const partnerNames = await Promise.all(member.partners.map(fetchMemberName));
-        names = partnerNames.filter(name => name !== null) as string[];
-      }
-
-      if (names.length > 0) {
-        setSpousePartnerName(names.join(', '));
-      } else {
-        setSpousePartnerName(null);
-      }
-    };
-
-    fetchSpouseOrPartnerNames();
-  }, [member.spouse, member.partners]);
 
   const handleClick = useCallback(() => {
     onSelect(member);
@@ -222,38 +167,6 @@ const FamilyMemberNodeInternal: React.FC<FamilyMemberNodeProps> = ({ data }) => 
                 <span>&nbsp;</span>
               )}
             </div>
-
-            {/* Parents Display */}
-            <div className="flex items-center text-xs text-slate-600 bg-slate-50 rounded-lg px-2 py-1 min-h-[2rem]">
-              {parentNames ? (
-                <>
-                  <Users className="w-3 h-3 mr-2 text-slate-400 flex-shrink-0" />
-                  <span className="truncate">{parentNames}</span>
-                </>
-              ) : (
-                <span>&nbsp;</span>
-              )}
-            </div>
-
-            {/* Spouse/Partner Display */}
-            <div className="flex items-center text-xs text-slate-600 bg-slate-50 rounded-lg px-2 py-1 min-h-[2rem]">
-              {spousePartnerName ? (
-                <>
-                  <Heart className="w-3 h-3 mr-2 text-slate-400 flex-shrink-0" />
-                  <span className="truncate">{spousePartnerName}</span>
-                </>
-              ) : (
-                <span>&nbsp;</span>
-              )}
-            </div>
-
-            {/* Co-parent Display */}
-            {member.coParentName && (
-              <div className="flex items-center text-xs text-slate-600 bg-slate-50 rounded-lg px-2 py-1 min-h-[2rem]">
-                <Users className="w-3 h-3 mr-2 text-slate-400 flex-shrink-0" />
-                <span className="truncate" title={member.coParentName}>Co-parent: {member.coParentName}</span>
-              </div>
-            )}
           </div>
         </div>
 

--- a/src/pages/Members.tsx
+++ b/src/pages/Members.tsx
@@ -2,7 +2,7 @@ import React, { useState, useEffect, useCallback } from 'react';
 import { supabase } from '../lib/supabaseClient'; 
 import { FamilyMember } from '../types/family';
 import { Card, CardContent, CardHeader, CardTitle } from '../components/ui/card';
-import { User, Calendar, MapPin, Briefcase, Heart, Droplets, Phone, Mail, Search, X } from 'lucide-react';
+import { User, Users, Calendar, MapPin, Briefcase, Heart, Droplets, Phone, Mail, Search, X } from 'lucide-react'; // Added Users
 import { Link } from 'react-router-dom';
 import ThemeToggleButton from '../components/ThemeToggleButton';
 
@@ -160,6 +160,13 @@ const Members = () => {
               const partners = getPartnerDetails(member);
               const age = calculateAge(member.birthDate, member.deathDate);
 
+              const parentDetails = member.parents && member.parents.length > 0
+                ? member.parents.map(parentId => {
+                    const parent = members.find(m => m.id === parentId);
+                    return parent ? parent.name : null;
+                  }).filter(name => name !== null) as string[]
+                : [];
+
               return (
                 <Card key={member.id} className="overflow-hidden hover:shadow-xl transition-shadow duration-300 dark:bg-slate-800">
                   <CardHeader className={`pb-4 ${member.gender === 'male' ? 'bg-gradient-to-r from-blue-500 to-indigo-600' : 'bg-gradient-to-r from-rose-500 to-pink-600'} text-white`}>
@@ -233,6 +240,22 @@ const Members = () => {
                         <div className="flex items-center text-sm text-gray-600 dark:text-slate-300">
                           <Mail className="w-4 h-4 mr-2 text-gray-400 dark:text-slate-500" />
                           <span>{member.email}</span>
+                        </div>
+                      )}
+
+                      {/* Display Parent Names */}
+                      {parentDetails.length > 0 && (
+                        <div className="flex items-center text-sm text-gray-600 dark:text-slate-300">
+                          <Users className="w-4 h-4 mr-2 text-gray-400 dark:text-slate-500" />
+                          <span>Parents: {parentDetails.join(' & ')}</span>
+                        </div>
+                      )}
+
+                      {/* Display Co-parent Name */}
+                      {member.coParentName && (
+                        <div className="flex items-center text-sm text-gray-600 dark:text-slate-300">
+                          <Users className="w-4 h-4 mr-2 text-gray-400 dark:text-slate-500" />
+                          <span>Co-parent: {member.coParentName}</span>
                         </div>
                       )}
                     </div>


### PR DESCRIPTION
This commit refactors how member details are displayed, based on your feedback:

1.  **FamilyMemberNode.tsx (Tree View)**:
    *   Reverted the recent additions of parent names, spouse/partner names, and coParentName.
    *   Nodes in the family tree now display only essential information (e.g., name, age, occupation, photo), providing a cleaner tree view.
    *   Removed associated data fetching logic for these fields from this component.

2.  **MemberModal.tsx (Tree Click Modal)**:
    *   Verified that this component continues to correctly fetch and display comprehensive member details from Supabase, including parents, spouse(s), partners, children, and coParentName. This remains the location for full details when interacting with the tree.

3.  **Members.tsx (Members Page Cards)**:
    *   Enhanced individual member cards to include parent names and coParentName.
    *   Parent names are resolved from the existing list of all fetched members.
    *   This makes the member cards on this page more informative, aligning them with the detail level expected outside the condensed tree view.

This set of changes ensures that detailed relational information is available upon specific request (modal) or on the dedicated members page, while keeping the main family tree visualization less cluttered.