### PR TITLE
fix: Correctly parse and display partners from comma-separated string

### DIFF
--- a/src/components/MemberModal.tsx
+++ b/src/components/MemberModal.tsx
@@ -13,23 +13,10 @@ const MemberModal: React.FC<MemberModalProps> = ({ member: initialMember, onClos
   const [detailedMember, setDetailedMember] = useState<FamilyMember | null>(null);
   const [parentNames, setParentNames] = useState<string[]>([]);
   const [childrenNames, setChildrenNames] = useState<string[]>([]);
-  const [spouseName, setSpouseName] = useState<string | null>(null);
-  const [partnerNames, setPartnerNames] = useState<string[]>([]);
+  // Removed spouseName and partnerNames state variables
   const [isLoading, setIsLoading] = useState<boolean>(true);
 
-  const fetchNameById = async (id: string): Promise<string | null> => {
-    if (!id) return null;
-    const { data, error } = await supabase
-      .from('family_members')
-      .select('name')
-      .eq('id', id)
-      .single();
-    if (error) {
-      console.error(`Error fetching name for ID ${id}:`, error);
-      return null;
-    }
-    return data?.name || null;
-  };
+  // Removed fetchNameById as it was only for spouse
 
   const fetchNamesByIds = async (ids: string[]): Promise<string[]> => {
     if (!ids || ids.length === 0) return [];
@@ -58,8 +45,7 @@ const MemberModal: React.FC<MemberModalProps> = ({ member: initialMember, onClos
       setDetailedMember(null); // Clear previous member details
       setParentNames([]);
       setChildrenNames([]);
-      setSpouseName(null);
-      setPartnerNames([]);
+      // Removed setSpouseName(null) and setPartnerNames([])
 
       try {
         // Fetch main member details
@@ -91,17 +77,8 @@ const MemberModal: React.FC<MemberModalProps> = ({ member: initialMember, onClos
             setChildrenNames(fetchedChildrenNames);
           }
 
-          // Fetch spouse
-          if (memberData.spouse) {
-            const fetchedSpouseName = await fetchNameById(memberData.spouse);
-            setSpouseName(fetchedSpouseName);
-          }
-
-          // Fetch partners
-          if (memberData.partners && memberData.partners.length > 0) {
-            const fetchedPartnerNames = await fetchNamesByIds(memberData.partners);
-            setPartnerNames(fetchedPartnerNames);
-          }
+          // Spouse and old partners array fetching removed
+          // The new memberData.partners is a string and needs no special fetching here
         }
       } catch (error) {
         console.error('Error in fetchModalData:', error);
@@ -161,6 +138,11 @@ const MemberModal: React.FC<MemberModalProps> = ({ member: initialMember, onClos
       </div>
     );
   }
+
+  // Process detailedMember.partners string
+  const currentPartnerNames = detailedMember?.partners && typeof detailedMember.partners === 'string'
+    ? detailedMember.partners.split(',').map(name => name.trim()).filter(name => name)
+    : [];
 
   return (
     <div className="fixed inset-0 bg-black bg-opacity-50 flex items-center justify-center z-[55] p-4"> {/* Changed z-50 to z-[55] */}
@@ -259,26 +241,15 @@ const MemberModal: React.FC<MemberModalProps> = ({ member: initialMember, onClos
 
             {/* Family Relationships */}
             <div className="space-y-4">
-              {spouseName && (
+              {/* New Partner(s) Display */}
+              {currentPartnerNames.length > 0 && (
                 <div>
                   <div className="flex items-center space-x-2 text-gray-600 mb-2">
                     <Heart className="h-5 w-5" />
-                    <p className="font-medium">Spouse</p>
-                  </div>
-                  <div className="bg-gray-50 rounded-lg p-3">
-                    <p className="font-medium">{spouseName}</p>
-                  </div>
-                </div>
-              )}
-
-              {partnerNames.length > 0 && (
-                <div>
-                  <div className="flex items-center space-x-2 text-gray-600 mb-2">
-                    <Heart className="h-5 w-5" /> {/* Consider a different icon for partners if desired */}
-                    <p className="font-medium">Partners</p>
+                    <p className="font-medium">Partner(s)</p>
                   </div>
                   <div className="space-y-2">
-                    {partnerNames.map((name, index) => (
+                    {currentPartnerNames.map((name, index) => (
                       <div key={index} className="bg-gray-50 rounded-lg p-3">
                         <p className="font-medium">{name}</p>
                       </div>

--- a/src/pages/Members.tsx
+++ b/src/pages/Members.tsx
@@ -33,19 +33,14 @@ const Members = () => {
     fetchPageMembers();
   }, [fetchPageMembers]);
 
-  const getPartnerDetails = (member: FamilyMember) => {
-    const partners: FamilyMember[] = [];
-    if (member.spouse) {
-      const spouse = members.find(m => m.id === member.spouse); 
-      if (spouse) partners.push(spouse);
+  // Updated getPartnerDetails to process comma-separated string
+  const getPartnerDetails = (member: FamilyMember): string[] => {
+    if (member.partners && typeof member.partners === 'string') {
+      return member.partners.split(',')
+        .map(name => name.trim())
+        .filter(name => name !== ''); // Ensure empty strings are not included
     }
-    if (member.partners) {
-      member.partners.forEach(partnerId => {
-        const partner = members.find(m => m.id === partnerId); 
-        if (partner) partners.push(partner);
-      });
-    }
-    return partners;
+    return [];
   };
 
   const calculateAge = (birthDate?: string, deathDate?: string) => {
@@ -260,43 +255,19 @@ const Members = () => {
                       )}
                     </div>
 
-                    {partners.length > 0 && (
+                    {/* Updated Partner Display */}
+                    {partners.length > 0 && ( // partners is now an array of strings (names)
                       <div className="border-t dark:border-slate-700 pt-4">
                         <div className="flex items-center mb-3">
                           <Heart className="w-4 h-4 mr-2 text-red-500" />
                           <span className="font-semibold text-gray-800 dark:text-slate-200">
-                            {partners.length === 1 ? 'Partner' : 'Partners'}
+                            Partner(s)
                           </span>
                         </div>
-                        {partners.map((partner) => (
-                          <div key={partner.id} className="bg-gray-50 dark:bg-slate-700/50 rounded-lg p-3 mb-2 last:mb-0">
-                            <div className="font-medium text-gray-800 dark:text-slate-200">{partner.name}</div>
-                            <div className="text-sm text-gray-600 dark:text-slate-300 space-y-1">
-                              {partner.occupation && (
-                                <div className="flex items-center">
-                                  <Briefcase className="w-3 h-3 mr-1 text-gray-400 dark:text-slate-500" />
-                                  <span>{partner.occupation}</span>
-                                </div>
-                              )}
-                              {partner.bloodType && (
-                                <div className="flex items-center">
-                                  <Droplets className="w-3 h-3 mr-1 text-gray-400 dark:text-slate-500" />
-                                  <span>Blood Type: {partner.bloodType}</span>
-                                </div>
-                              )}
-                              {partner.mobileNumber && (
-                                <div className="flex items-center">
-                                  <Phone className="w-3 h-3 mr-1 text-gray-400 dark:text-slate-500" />
-                                  <span>{partner.mobileNumber}</span>
-                                </div>
-                              )}
-                              {partner.email && (
-                                <div className="flex items-center">
-                                  <Mail className="w-3 h-3 mr-1 text-gray-400 dark:text-slate-500" />
-                                  <span>{partner.email}</span>
-                                </div>
-                              )}
-                            </div>
+                        {partners.map((name, index) => (
+                          <div key={index} className="bg-gray-50 dark:bg-slate-700/50 rounded-lg p-3 mb-2 last:mb-0">
+                            <div className="font-medium text-gray-800 dark:text-slate-200">{name}</div>
+                            {/* Other partner details like occupation, blood type, etc., are removed as they are not available from the string */}
                           </div>
                         ))}
                       </div>

--- a/src/types/family.ts
+++ b/src/types/family.ts
@@ -12,8 +12,10 @@ export interface FamilyMember {
   generation: number;
   parents?: string[];
   children?: string[];
-  spouse?: string;
-  partners?: string[]; // For multiple partners
+  // spouse?: string; // Replaced by new partners field
+  // partners?: string[]; // Replaced by new partners field, now a comma-separated string
+  // Comma-separated string of partner names
+  partners?: string;
   bloodType?: string;
   mobileNumber?: string;
   email?: string;


### PR DESCRIPTION
This commit addresses your feedback regarding the storage and display of partner/spouse information. The database stores partner names as a single comma-separated string in a 'partners' column, not as individual spouse IDs or an array of partner IDs.

Changes include:

1.  **Type Definition (`src/types/family.ts`)**:
    *   Modified the `FamilyMember` interface to define `partners?: string;` as a field for a comma-separated string of names.
    *   Commented out the previous `spouse?: string;` (for ID) and `partners?: string[];` (for array of IDs) fields.

2.  **Member Modal (`src/components/MemberModal.tsx`)**:
    *   Removed state and fetching logic related to the old `spouse` (ID) and `partners` (array of IDs) fields.
    *   The component now directly uses the `detailedMember.partners` string.
    *   This string is split by commas, and names are trimmed to correctly display a list of partner(s).
    *   The `fetchNameById` helper function was removed as it's no longer used.

3.  **Members Page (`src/pages/Members.tsx`)**:
    *   Updated the `getPartnerDetails` function to parse the `member.partners` comma-separated string into an array of names.
    *   Member cards now display only the names of partners based on this parsed string.
    *   Removed UI elements that previously attempted to show extended details (e.g., occupation, contact info) for partners, as only names are available from this field.

This ensures that partner information is accurately processed and displayed according to the actual database schema and your requirements.