### PR TITLE
fix: Switch to HashRouter for GitHub Pages compatibility

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -2,7 +2,7 @@ import { Toaster } from "@/components/ui/toaster";
 import { Toaster as Sonner } from "@/components/ui/sonner";
 import { TooltipProvider } from "@/components/ui/tooltip";
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
-import { BrowserRouter, Routes, Route } from "react-router-dom";
+import { HashRouter, Routes, Route } from "react-router-dom"; // Changed BrowserRouter to HashRouter
 import Index from "./pages/Index";
 import Members from "./pages/Members";
 import Magazines from "./pages/Magazines";
@@ -17,7 +17,7 @@ const App = () => (
       <TooltipProvider>
         <Toaster />
         <Sonner />
-        <BrowserRouter>
+        <HashRouter> {/* Changed BrowserRouter to HashRouter */}
           <Routes>
             <Route path="/" element={<Index />} />
             <Route path="/members" element={<Members />} />
@@ -25,7 +25,7 @@ const App = () => (
             {/* ADD ALL CUSTOM ROUTES ABOVE THE CATCH-ALL "*" ROUTE */}
             <Route path="*" element={<NotFound />} />
           </Routes>
-        </BrowserRouter>
+        </HashRouter> {/* Changed BrowserRouter to HashRouter */}
       </TooltipProvider>
     </AuthProvider> {/* Close AuthProvider */}
   </QueryClientProvider>


### PR DESCRIPTION
Replaces BrowserRouter with HashRouter in src/App.tsx.

This change is made to ensure proper routing functionality when the application is hosted on static platforms like GitHub Pages. Using HashRouter prevents 404 errors when you directly navigate to or refresh specific routes, as the path is handled client-side after the hash (#) symbol.

The application's URLs will now include a '#' (e.g., /#/members).