### PR TITLE
fix: Correctly parse stringified array for partners field

### DIFF
--- a/src/components/MemberModal.tsx
+++ b/src/components/MemberModal.tsx
@@ -1,8 +1,55 @@
 
-import React, { useEffect, useState } from 'react';
+import React, { useEffect, useState, useMemo } from 'react'; // Added useMemo
 import { X, Calendar, MapPin, Briefcase, Heart, Users, User } from 'lucide-react';
 import { FamilyMember } from '../types/family';
 import { supabase } from '../lib/supabaseClient';
+
+// Helper function to parse the partners string
+const parsePartnerString = (partnersStr: string | null | undefined): string[] => {
+  if (!partnersStr || partnersStr.trim() === '') {
+    return [];
+  }
+
+  // Attempt JSON.parse
+  try {
+    const parsed = JSON.parse(partnersStr);
+    if (Array.isArray(parsed) && parsed.every(item => typeof item === 'string')) {
+      return parsed.map(name => name.trim()).filter(name => name.length > 0);
+    }
+    // If JSON.parse succeeds but it's not an array of strings, it's an unexpected JSON format.
+    console.warn("Partners string parsed as JSON but is not an array of strings:", parsed);
+  } catch (e) {
+    // JSON.parse failed, proceed to next method or log for debugging
+    // console.warn("JSON.parse failed for partners string (will try pg-like):", partnersStr, e); // Can be too noisy if pg-like is common
+  }
+
+  // Attempt PostgreSQL-like text array parsing
+  if (partnersStr.startsWith('{') && partnersStr.endsWith('}')) {
+    try {
+      const innerStr = partnersStr.substring(1, partnersStr.length - 1);
+      if (innerStr.trim() === '') return []; // Handle empty array like '{}'
+
+      const names = innerStr.split(',').map(name => {
+        let trimmedName = name.trim();
+        if (trimmedName.startsWith('"') && trimmedName.endsWith('"')) {
+          trimmedName = trimmedName.substring(1, trimmedName.length - 1);
+          trimmedName = trimmedName.replace(/""/g, '"'); // Replace pg's double-quote escape ""
+        }
+        return trimmedName;
+      }).filter(name => name.length > 0);
+
+      if (names.length > 0 && names.some(name => name.length > 0)) {
+        // console.log("Parsed partners string via pg-like array method:", names); // Optional: for debugging
+        return names;
+      }
+    } catch (e) {
+      console.error("Error parsing PostgreSQL-like array string:", partnersStr, e);
+    }
+  }
+
+  console.warn("Could not parse partners string using known methods. String was:", partnersStr);
+  return [];
+};
 
 interface MemberModalProps {
   member: FamilyMember; // This will be the initially passed member, might be partial
@@ -139,10 +186,8 @@ const MemberModal: React.FC<MemberModalProps> = ({ member: initialMember, onClos
     );
   }
 
-  // Process detailedMember.partners string
-  const currentPartnerNames = detailedMember?.partners && typeof detailedMember.partners === 'string'
-    ? detailedMember.partners.split(',').map(name => name.trim()).filter(name => name)
-    : [];
+  // Process detailedMember.partners string using the helper and useMemo
+  const currentPartnerNames = useMemo(() => parsePartnerString(detailedMember?.partners), [detailedMember?.partners]);
 
   return (
     <div className="fixed inset-0 bg-black bg-opacity-50 flex items-center justify-center z-[55] p-4"> {/* Changed z-50 to z-[55] */}

--- a/src/types/family.ts
+++ b/src/types/family.ts
@@ -14,7 +14,7 @@ export interface FamilyMember {
   children?: string[];
   // spouse?: string; // Replaced by new partners field
   // partners?: string[]; // Replaced by new partners field, now a comma-separated string
-  // Comma-separated string of partner names
+  // Raw string from DB representing an array of partner names (e.g., JSON string like '["name1", "name2"]' or PostgreSQL text array like '{"name1","name2"}')
   partners?: string;
   bloodType?: string;
   mobileNumber?: string;


### PR DESCRIPTION
I've updated the parsing logic for the 'partners' field in MemberModal.tsx and Members.tsx to handle string representations of arrays (JSON or PostgreSQL text array formats) as per your feedback.

Previously, I assumed the 'partners' field was a simple comma-separated string. The new information reveals it's a string that itself represents an array (e.g., '["spouse1", "spouse2"]' or '{"spouse1","spouse2"}').

Here's what I changed:
- Updated the type comment in `src/types/family.ts` for the `partners` field to reflect its stringified array nature.
- Implemented a `parsePartnerString` helper function that:
  - First attempts `JSON.parse()` on the input string.
  - If JSON parsing fails, attempts to parse PostgreSQL-style text array strings (handling braces and quoted elements).
  - Includes try-catch blocks for robust error handling, defaulting to an empty array if parsing fails.
- Integrated `parsePartnerString` into `MemberModal.tsx` for displaying partner names in the member details modal.
- Integrated `parsePartnerString` into `Members.tsx` (via `getPartnerDetails` function) for displaying partner names on member cards.

This ensures accurate display of partner names from the database.