### PR TITLE
fix: Correct hook call order in MemberModal

### DIFF
--- a/src/components/MemberModal.tsx
+++ b/src/components/MemberModal.tsx
@@ -3,57 +3,7 @@ import React, { useEffect, useState, useMemo } from 'react'; // Added useMemo
 import { X, Calendar, MapPin, Briefcase, Heart, Users, User } from 'lucide-react';
 import { FamilyMember } from '../types/family';
 import { supabase } from '../lib/supabaseClient';
-
-// Helper function to parse the partners string
-const parsePartnerString = (partnersStr: string | null | undefined): string[] => {
-  if (!partnersStr || partnersStr.trim() === '') {
-    return [];
-  }
-
-  // Attempt JSON.parse
-  try {
-    const parsed = JSON.parse(partnersStr);
-    if (Array.isArray(parsed)) {
-      // Filter for strings first, then map and filter by length
-      return parsed
-        .filter(item => typeof item === 'string')
-        .map(name => name.trim())
-        .filter(name => name.length > 0);
-    }
-    // If JSON.parse succeeds but it's not an array (e.g., a single string, number, or object), it's an unexpected JSON format.
-    console.warn("Partners string parsed as JSON but is not an array:", parsed);
-  } catch (e) {
-    // JSON.parse failed, proceed to next method or log for debugging
-    // console.warn("JSON.parse failed for partners string (will try pg-like):", partnersStr, e); // Can be too noisy if pg-like is common
-  }
-
-  // Attempt PostgreSQL-like text array parsing
-  if (partnersStr.startsWith('{') && partnersStr.endsWith('}')) {
-    try {
-      const innerStr = partnersStr.substring(1, partnersStr.length - 1);
-      if (innerStr.trim() === '') return []; // Handle empty array like '{}'
-
-      const names = innerStr.split(',').map(name => {
-        let trimmedName = name.trim();
-        if (trimmedName.startsWith('"') && trimmedName.endsWith('"')) {
-          trimmedName = trimmedName.substring(1, trimmedName.length - 1);
-          trimmedName = trimmedName.replace(/""/g, '"'); // Replace pg's double-quote escape ""
-        }
-        return trimmedName;
-      }).filter(name => name.length > 0);
-
-      if (names.length > 0 && names.some(name => name.length > 0)) {
-        // console.log("Parsed partners string via pg-like array method:", names); // Optional: for debugging
-        return names;
-      }
-    } catch (e) {
-      console.error("Error parsing PostgreSQL-like array string:", partnersStr, e);
-    }
-  }
-
-  console.warn("Could not parse partners string using known methods. String was:", partnersStr);
-  return [];
-};
+import { parsePartnerString } from '../lib/stringUtils'; // Import shared function
 
 interface MemberModalProps {
   member: FamilyMember; // This will be the initially passed member, might be partial
@@ -66,6 +16,9 @@ const MemberModal: React.FC<MemberModalProps> = ({ member: initialMember, onClos
   const [childrenNames, setChildrenNames] = useState<string[]>([]);
   // Removed spouseName and partnerNames state variables
   const [isLoading, setIsLoading] = useState<boolean>(true);
+
+  // Process detailedMember.partners string using the helper and useMemo - MOVED HERE
+  const currentPartnerNames = useMemo(() => parsePartnerString(detailedMember?.partners), [detailedMember?.partners]);
 
   // Removed fetchNameById as it was only for spouse
 
@@ -189,9 +142,6 @@ const MemberModal: React.FC<MemberModalProps> = ({ member: initialMember, onClos
       </div>
     );
   }
-
-  // Process detailedMember.partners string using the helper and useMemo
-  const currentPartnerNames = useMemo(() => parsePartnerString(detailedMember?.partners), [detailedMember?.partners]);
 
   return (
     <div className="fixed inset-0 bg-black bg-opacity-50 flex items-center justify-center z-[55] p-4"> {/* Changed z-50 to z-[55] */}

--- a/src/lib/stringUtils.ts
+++ b/src/lib/stringUtils.ts
@@ -1,0 +1,50 @@
+// Helper function to parse the partners string
+export const parsePartnerString = (partnersStr: string | null | undefined): string[] => {
+  if (!partnersStr || partnersStr.trim() === '') {
+    return [];
+  }
+
+  // Attempt JSON.parse
+  try {
+    const parsed = JSON.parse(partnersStr);
+    if (Array.isArray(parsed)) {
+      // Filter for strings first, then map and filter by length
+      return parsed
+        .filter(item => typeof item === 'string')
+        .map(name => name.trim())
+        .filter(name => name.length > 0);
+    }
+    // If JSON.parse succeeds but it's not an array (e.g., a single string, number, or object), it's an unexpected JSON format.
+    console.warn("Partners string parsed as JSON but is not an array:", parsed);
+  } catch (e) {
+    // JSON.parse failed, proceed to next method or log for debugging
+    // console.warn("JSON.parse failed for partners string (will try pg-like):", partnersStr, e); // Can be too noisy if pg-like is common
+  }
+
+  // Attempt PostgreSQL-like text array parsing
+  if (partnersStr.startsWith('{') && partnersStr.endsWith('}')) {
+    try {
+      const innerStr = partnersStr.substring(1, partnersStr.length - 1);
+      if (innerStr.trim() === '') return []; // Handle empty array like '{}'
+
+      const names = innerStr.split(',').map(name => {
+        let trimmedName = name.trim();
+        if (trimmedName.startsWith('"') && trimmedName.endsWith('"')) {
+          trimmedName = trimmedName.substring(1, trimmedName.length - 1);
+          trimmedName = trimmedName.replace(/""/g, '"'); // Replace pg's double-quote escape ""
+        }
+        return trimmedName;
+      }).filter(name => name.length > 0);
+
+      if (names.length > 0 && names.some(name => name.length > 0)) {
+        // console.log("Parsed partners string via pg-like array method:", names); // Optional: for debugging
+        return names;
+      }
+    } catch (e) {
+      console.error("Error parsing PostgreSQL-like array string:", partnersStr, e);
+    }
+  }
+
+  console.warn("Could not parse partners string using known methods. String was:", partnersStr);
+  return [];
+};

--- a/src/pages/Members.tsx
+++ b/src/pages/Members.tsx
@@ -5,55 +5,7 @@ import { Card, CardContent, CardHeader, CardTitle } from '../components/ui/card'
 import { User, Users, Calendar, MapPin, Briefcase, Heart, Droplets, Phone, Mail, Search, X } from 'lucide-react'; // Added Users
 import { Link } from 'react-router-dom';
 import ThemeToggleButton from '../components/ThemeToggleButton';
-
-// Helper function to parse the partners string (same as in MemberModal.tsx)
-const parsePartnerString = (partnersStr: string | null | undefined): string[] => {
-  if (!partnersStr || partnersStr.trim() === '') {
-    return [];
-  }
-
-  // Attempt JSON.parse
-  try {
-    const parsed = JSON.parse(partnersStr);
-    if (Array.isArray(parsed)) {
-      // Filter for strings first, then map and filter by length
-      return parsed
-        .filter(item => typeof item === 'string')
-        .map(name => name.trim())
-        .filter(name => name.length > 0);
-    }
-    // If JSON.parse succeeds but it's not an array (e.g., a single string, number, or object), it's an unexpected JSON format.
-    console.warn("Partners string parsed as JSON but is not an array:", parsed);
-  } catch (e) {
-    // console.warn("JSON.parse failed for partners string (will try pg-like):", partnersStr, e);
-  }
-
-  // Attempt PostgreSQL-like text array parsing
-  if (partnersStr.startsWith('{') && partnersStr.endsWith('}')) {
-    try {
-      const innerStr = partnersStr.substring(1, partnersStr.length - 1);
-      if (innerStr.trim() === '') return [];
-
-      const names = innerStr.split(',').map(name => {
-        let trimmedName = name.trim();
-        if (trimmedName.startsWith('"') && trimmedName.endsWith('"')) {
-          trimmedName = trimmedName.substring(1, trimmedName.length - 1);
-          trimmedName = trimmedName.replace(/""/g, '"');
-        }
-        return trimmedName;
-      }).filter(name => name.length > 0);
-
-      if (names.length > 0 && names.some(name => name.length > 0)) {
-        return names;
-      }
-    } catch (e) {
-      console.error("Error parsing PostgreSQL-like array string:", partnersStr, e);
-    }
-  }
-
-  console.warn("Could not parse partners string using known methods. String was:", partnersStr);
-  return [];
-};
+import { parsePartnerString } from '../lib/stringUtils'; // Import shared function
 
 const Members = () => {
   const [searchQuery, setSearchQuery] = useState('');


### PR DESCRIPTION
Moves the `useMemo` hook for `currentPartnerNames` in `src/components/MemberModal.tsx` to the top level of the functional component.

This change ensures that all hooks are called in the same order on every render, preventing the "Rendered more hooks than during the previous render" (React Error #310). The `parsePartnerString` function used within this `useMemo` is designed to handle potentially null or undefined inputs that might occur before `detailedMember` is fully loaded, making this move safe.

This fix should resolve the React Error #310 and may also help stabilize the component, potentially resolving other downstream errors.