### PR TITLE
fix: Harden initial trim in parsePartnerString

### DIFF
--- a/src/lib/stringUtils.ts
+++ b/src/lib/stringUtils.ts
@@ -1,6 +1,6 @@
 // Helper function to parse the partners string
 export const parsePartnerString = (partnersStr: string | null | undefined): string[] => {
-  if (!partnersStr || partnersStr.trim() === '') {
+  if (typeof partnersStr !== 'string' || partnersStr.trim() === '') {
     return [];
   }
 


### PR DESCRIPTION
Strengthens the initial input validation within the `parsePartnerString` function in `src/lib/stringUtils.ts`. The check is changed from `!partnersStr || partnersStr.trim() === ''` to
`typeof partnersStr !== 'string' || partnersStr.trim() === ''`.

This ensures that `partnersStr.trim()` is only called if `partnersStr` is explicitly a string. This change is intended to definitively resolve any 'TypeError: e.trim is not a function' errors that might have occurred if `partnersStr` itself was not a string at the point of the initial trim, which the minified stack traces suggested could be the case.

The internal logic for trimming elements within a parsed JSON array was already confirmed to be safe with its `filter(item => typeof item === 'string')` guard. This commit hardens the handling of the main input string.