### PR TITLE
fix: Add diagnostics for collapse/expand button visibility

### DIFF
--- a/src/components/FamilyMemberNode.tsx
+++ b/src/components/FamilyMemberNode.tsx
@@ -66,6 +66,9 @@ const FamilyMemberNodeInternal: React.FC<FamilyMemberNodeProps> = ({ data }) => 
     }
   }, [member.id, onToggleCollapse]);
 
+  // Diagnostic log
+  console.log(`Node: ${member.name}, hasChildren: ${hasChildren}, onToggleCollapse defined: ${!!onToggleCollapse}`);
+
   return (
     <div className="family-member-node">
       <Handle

--- a/src/lib/layoutFamilyTree.ts
+++ b/src/lib/layoutFamilyTree.ts
@@ -240,7 +240,7 @@ export function layoutFamilyTree(
     // For Person/Lineage, this is implicitly handled by the initial filtering.
     // The `hasChildren` prop for the button should reflect if there *are* children in allMembers,
     // not just currently visible ones.
-    const hasAnyChildren = allMembers.some(child => child.parents?.includes(member.id));
+    const hasAnyChildren = !!allMembers.some(child => child.parents?.includes(member.id)); // Explicit boolean cast
     
     return {
         id: member.id,


### PR DESCRIPTION
This commit introduces diagnostic logging to help investigate reports of missing +/- collapse/expand buttons on nodes. It also includes a minor defensive coding improvement.

Changes:
- Added a `console.log` statement in `FamilyMemberNode.tsx` to output the `member.name`, `hasChildren` prop, and the presence of the `onToggleCollapse` callback for each rendered node. This will provide valuable information if the issue is related to incorrect prop values in specific scenarios.
- Explicitly cast the `hasChildren` variable in `src/lib/layoutFamilyTree.ts` to a boolean using `!!`. While `Array.prototype.some` already returns a boolean, this makes the type intention perfectly clear and is a safe, defensive measure.

The core logic for determining whether to show the collapse/expand buttons (checking if a node has children in the underlying data and if a collapse callback is provided) was reviewed and appears correct. These changes aim to assist in diagnosing why you might not be seeing the buttons as expected.