### PR TITLE
feat: Implement floating page navigation

### DIFF
--- a/src/components/FloatingPageNav.tsx
+++ b/src/components/FloatingPageNav.tsx
@@ -1,0 +1,14 @@
+import React from 'react';
+import { Link } from 'react-router-dom';
+
+const FloatingPageNav: React.FC = () => {
+  return (
+    <nav className="hidden md:flex md:space-x-4 fixed top-4 right-4 z-50 bg-slate-200/30 dark:bg-slate-900/30 backdrop-blur-md rounded-full px-6 py-3 shadow-lg ring-1 ring-slate-900/5">
+      <Link to="/" className="text-emerald-600 dark:text-emerald-400 font-medium">Home</Link>
+      <Link to="/members" className="text-gray-600 dark:text-slate-300 hover:text-emerald-600 dark:hover:text-emerald-400 transition-colors">Members</Link>
+      <Link to="/magazines" className="text-gray-600 dark:text-slate-300 hover:text-emerald-600 dark:hover:text-emerald-400 transition-colors">Magazines</Link>
+    </nav>
+  );
+};
+
+export default FloatingPageNav;

--- a/src/pages/Index.tsx
+++ b/src/pages/Index.tsx
@@ -10,6 +10,7 @@ import {
   DropdownMenuTrigger,
 } from "@/components/ui/dropdown-menu";
 import ThemeToggleButton from '../components/ThemeToggleButton';
+import FloatingPageNav from '../components/FloatingPageNav'; // Added import
 import Sidebar from '../components/Sidebar';
 import FamilyTree from '../components/FamilyTree';
 import MemberModal from '../components/MemberModal';
@@ -265,11 +266,8 @@ const Index = () => {
               <h1 className="text-2xl font-bold text-emerald-800 dark:text-emerald-300">Unity Valiyangadi</h1>
             </div>
             <div className="flex items-center min-w-0">
-              <nav className="hidden md:flex space-x-8 mr-4">
-                <Link to="/" className="text-emerald-600 dark:text-emerald-400 font-medium">Home</Link>
-                <Link to="/members" className="text-gray-600 dark:text-slate-300 hover:text-emerald-600 dark:hover:text-emerald-400 transition-colors">Members</Link>
-                <Link to="/magazines" className="text-gray-600 dark:text-slate-300 hover:text-emerald-600 dark:hover:text-emerald-400 transition-colors">Magazines</Link>
-              </nav>
+              {/* FloatingPageNav is positioned fixed, so it doesn't need to be in this flex flow for layout */}
+              <FloatingPageNav />
 
               {/* Auth Buttons Block - Desktop Only */}
               <div className="hidden md:flex items-center">


### PR DESCRIPTION
- Extracted page navigation links (Home, Members, Magazines) into a new component `FloatingPageNav.tsx`.
- Styled `FloatingPageNav` as a floating element positioned at the top-right of the page, with a blurred background, rounded corners, and shadow.
- Integrated `FloatingPageNav` into `Index.tsx`.
- Ensured the new floating navigation is responsive:
  - Visible on medium screens and larger (`md:flex`).
  - Hidden on small screens (`hidden`), retaining the mobile drawer for page navigation on these sizes.
- This addresses your request to make the navbar with page buttons have a floating design.